### PR TITLE
Feat/gi 27

### DIFF
--- a/src/app/agenda/agenda-details/agenda-details.page.scss
+++ b/src/app/agenda/agenda-details/agenda-details.page.scss
@@ -6,7 +6,7 @@
   align-items: end;
   overflow: hidden;
   width: 100%;
-  max-height: 246px;
+  height: 246px;
 }
 
 .full-height {

--- a/src/app/agenda/agenda-details/agenda-details.page.scss
+++ b/src/app/agenda/agenda-details/agenda-details.page.scss
@@ -6,7 +6,7 @@
   align-items: end;
   overflow: hidden;
   width: 100%;
-  height: 200px;
+  max-height: 246px;
 }
 
 .full-height {

--- a/src/app/agenda/agenda-details/agenda-details.page.ts
+++ b/src/app/agenda/agenda-details/agenda-details.page.ts
@@ -81,14 +81,14 @@ export class AgendaDetailsPage implements OnInit {
       .create()
       .addElement(document.getElementById('date-container'))
       .duration(400)
-      .fromTo('height', '200px', '0px')
+      .fromTo('height', '246px', '0px')
       .easing('ease-in-out');
 
     this.openCalendar = this.animationController
       .create()
       .addElement(document.getElementById('date-container'))
       .duration(400)
-      .fromTo('height', '0px', '200px')
+      .fromTo('height', '0px', '246px')
       .easing('ease-in-out');
 
     this.closeConfirmApoointment = this.animationController

--- a/src/app/components/date-picker/date-picker.component.html
+++ b/src/app/components/date-picker/date-picker.component.html
@@ -6,16 +6,15 @@
   <!--    <ion-button fill="clear" [disabled]="!hasYearSelection()" (click)="showYearView()" class="calendar-button">-->
   <!--      {{yearSelected}}-->
   <!--    </ion-button>-->
-
-  <!--    <span slot="end" *ngIf="hasPrevious() || hasNext()">-->
-  <!--            <ion-button  fill="clear" [disabled]="!hasPrevious()" (click)="previous()">-->
-  <!--                <ion-icon slot="icon-only" name="ios-arrow-back"></ion-icon>-->
-  <!--            </ion-button>-->
-  <!--            <ion-button fill="clear" [disabled]="!hasNext()" (click)="next()">-->
-  <!--                <ion-icon slot="icon-only" name="ios-arrow-forward"></ion-icon>-->
-  <!--            </ion-button>-->
-  <!--        </span>-->
-  <!--  </ion-item>-->
+  <ion-item [ngStyle]="backgroundStyle" lines="none" *ngIf="hasPrevious() || hasNext()">
+      <ion-button  slot="start" fill="clear" [disabled]="!hasPrevious()" (click)="previous()">
+          <ion-icon slot="icon-only" name="chevron-back-outline"></ion-icon>
+      </ion-button>
+      <ion-label class="ion-text-center">{{getMonthName()}} de {{yearSelected}}</ion-label>
+      <ion-button slot="end" fill="clear" [disabled]="!hasNext()" (click)="next()">
+          <ion-icon slot="icon-only" name="chevron-forward-outline"></ion-icon>
+      </ion-button>
+  </ion-item>
 
   <ion-grid *ngIf="showView === 'calendar'">
     <ion-row class="ion-justify-content-center">

--- a/src/app/components/date-picker/date-picker.component.html
+++ b/src/app/components/date-picker/date-picker.component.html
@@ -26,7 +26,7 @@
         {{ daylabel }}
       </ion-col>
     </ion-row>
-    <ion-row *ngFor="let week of weeks" class="ion-justify-content-center">
+    <ion-row *ngFor="let week of weeks" class="ion-justify-content-center height-fixed">
       <ion-col
         *ngFor="let day of week"
         (click)="selectDay(day)"
@@ -39,7 +39,7 @@
             [ngStyle]="
               isValidDay(day) && !isOneOfTheValidDates(day) && invalidDateStyle
             "
-            >{{ isValidDay(day) ? day.dayOfMonth : '&nbsp;&nbsp;' }}</span
+            ><div [ngStyle]="getDaySelectedStyle(day)"> {{ isValidDay(day) ? day.dayOfMonth : '&nbsp;&nbsp;' }}</div></span
           >
         </span>
       </ion-col>

--- a/src/app/components/date-picker/date-picker.component.scss
+++ b/src/app/components/date-picker/date-picker.component.scss
@@ -7,6 +7,7 @@
 .day-number{
   font-family: Roboto, monospace;
   font-size: 12px;
+  text-align: center;
 }
 
 ion-icon {

--- a/src/app/components/date-picker/date-picker.component.scss
+++ b/src/app/components/date-picker/date-picker.component.scss
@@ -37,3 +37,8 @@ ion-icon {
 .invalidMonth {
   color: #8b8b8b
 }
+
+.height-fixed {
+  height: 25px;
+  line-height: 2;
+}

--- a/src/app/components/date-picker/date-picker.component.ts
+++ b/src/app/components/date-picker/date-picker.component.ts
@@ -44,9 +44,9 @@ export class DatePickerComponent implements OnInit {
   @Input() monthLabelsStyle = { 'font-size': '15px' };
   @Input() yearLabelsStyle = { 'font-size': '15px' };
   @Input() itemSelectedStyle = {
-    background: 'var(--ion-color-primary)',
-    color: '#f4f4f4 !important',
-    borderRadius: '25%/50%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
   };
   @Input() invalidDateStyle = {
     'text-decoration': 'line-through',
@@ -57,9 +57,33 @@ export class DatePickerComponent implements OnInit {
   };
 
   @Input() todaySelectedStyle = {
-    background: 'var(--ion-color-primary)',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
     color: '#ffffff',
-    borderRadius: '25%/50%',
+  }
+
+  @Input() insideitemSelectedStyle = {
+    textAlign: 'center',
+    backgroundColor: 'var(--ion-color-primary)',
+    width: '25px',
+    height: '25px',
+    borderRadius: '50%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden'
+  }
+
+  @Input() insideTodaySelectedStyle = {
+    textAlign: 'center',
+    backgroundColor: 'var(--ion-color-primary)',
+    width: '25px',
+    height: '25px',
+    borderRadius: '50%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
   }
 
   @Output() onSelect: EventEmitter<Date> = new EventEmitter();
@@ -425,6 +449,23 @@ export class DatePickerComponent implements OnInit {
       ];
     if (dayStyle) {
       style = { ...style, ...dayStyle };
+    }
+
+    return style;
+  }
+
+  getDaySelectedStyle(day: Day) {
+    let style = {}
+
+    if (
+      this.daySelected &&
+      day.dayIdentifier === this.daySelected.dayIdentifier
+    ) {
+      if (this.isToday(this.daySelected.dayOfMonth)) {
+        style = { ...style, ...this.insideTodaySelectedStyle};
+      } else {
+        style = { ...style, ...this.insideitemSelectedStyle};
+      }
     }
 
     return style;

--- a/src/app/components/date-picker/date-picker.component.ts
+++ b/src/app/components/date-picker/date-picker.component.ts
@@ -14,18 +14,18 @@ export class DatePickerComponent implements OnInit {
   constructor(private animationController: AnimationController) {}
 
   @Input() monthLabels = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
+    'Enero',
+    'Febrero',
+    'Marzo',
+    'Abril',
+    'Mayo',
+    'Junio',
+    'Julio',
+    'Agosto',
+    'Septiembre',
+    'Octubre',
+    'Noviembre',
+    'Diciembre'
   ];
   @Input() dayLabels = ['Do', 'Lu', 'Ma', 'Mi', 'Ju', 'Vi', 'Sa'];
   @Input() date: Date;
@@ -44,14 +44,23 @@ export class DatePickerComponent implements OnInit {
   @Input() monthLabelsStyle = { 'font-size': '15px' };
   @Input() yearLabelsStyle = { 'font-size': '15px' };
   @Input() itemSelectedStyle = {
-    background: '#488aff',
+    background: 'var(--ion-color-primary)',
     color: '#f4f4f4 !important',
+    borderRadius: '25%/50%',
   };
   @Input() invalidDateStyle = {
     'text-decoration': 'line-through',
     color: 'red',
   };
-  @Input() todaysItemStyle = { color: 'var(--ion-color-primary)' };
+  @Input() todaysItemStyle = {
+    color: 'var(--ion-color-primary)'
+  };
+
+  @Input() todaySelectedStyle = {
+    background: 'var(--ion-color-primary)',
+    color: '#ffffff',
+    borderRadius: '25%/50%',
+  }
 
   @Output() onSelect: EventEmitter<Date> = new EventEmitter();
 
@@ -73,7 +82,7 @@ export class DatePickerComponent implements OnInit {
   endYear: number;
 
   ngOnInit() {
-
+    console.log(this.date)
     this.initOptions();
     this.createCalendarWeeks();
   }
@@ -118,9 +127,6 @@ export class DatePickerComponent implements OnInit {
     }
   }
 
-  public async hideCalendar() {
-
-  }
   createCalendarWeeks() {
     this.weeks = this.generateCalendarWeeks(
       Day.fromDate(
@@ -305,7 +311,7 @@ export class DatePickerComponent implements OnInit {
     return (
       this.yearSelected === this.currentYear &&
       this.monthSelected === this.currentMonth &&
-      this.currentDay === day
+      day === this.currentDay
     );
   }
 
@@ -386,6 +392,10 @@ export class DatePickerComponent implements OnInit {
     );
   }
 
+  getMonthName() {
+    return this.monthLabels[this.monthSelected - 1]
+  }
+
   //Styles
 
   getDayStyle(day: Day) {
@@ -398,7 +408,11 @@ export class DatePickerComponent implements OnInit {
       this.daySelected &&
       day.dayIdentifier === this.daySelected.dayIdentifier
     ) {
-      style = { ...style, ...this.itemSelectedStyle };
+      if (this.isToday(this.daySelected.dayOfMonth)) {
+        style = { ...style, ...this.todaySelectedStyle};
+      } else {
+        style = { ...style, ...this.itemSelectedStyle};
+      }
     }
 
     const dayStyle =


### PR DESCRIPTION
Cambiado el rectángulo azul de selección de día por un circulo.

He puesto, al menos temporalmente, la altura de los calendarios en altura fija, ya que de lo contrario tal y como están hechas las animaciones de abrir y cerrar el calendario, no funcionaban bien visualmente. Quizá hay que cambiarlo. Podríamos probarlo a ver qué nos parece.