### PR TITLE
fix: 🐛 bump min sdk to android 22

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -23,7 +23,7 @@
     <preference name="KeyboardDisplayRequiresUserAction" value="false" />
     <preference name="KeyboardResizeMode" value="ionic" />
     <platform name="android">
-        <preference name="android-minSdkVersion" value="24" />
+        <preference name="android-minSdkVersion" value="22" />
         <preference name="android-targetSdkVersion" value="29" />
     </platform>
     <platform name="android">


### PR DESCRIPTION
## Fix android installation for android < 7.0

## Objetivo de la PR

Permitir instalar la aplicacion en android 6.0

## Como probar

- Paso 1 Configurar un emulador con android 6.0.
- Paso 2 Correrlo con cordova.
```
  cordova prepare android && cordova run android --emulator
```
- Paso 3 Comprobar que la aplicacion se abre correctamente

## Comentarios adicionales y requerimientos para el revisor.

Se requiere revision funcional
