### PR TITLE
[GIK-134] Mostrar las horas internas a las que esta abierta la agenda

### DIFF
--- a/src/app/agenda/agenda-details/agenda-details.page.html
+++ b/src/app/agenda/agenda-details/agenda-details.page.html
@@ -35,6 +35,7 @@
 
     <app-day-timeline
       [appointments]="appointmentsService.appointments$"
+      [intervals]="intervals"
       [startDate]="startDate"
       [endDate]="endDate"
       [intervalsLength]="interval"

--- a/src/app/agenda/agenda-details/agenda-details.page.html
+++ b/src/app/agenda/agenda-details/agenda-details.page.html
@@ -34,7 +34,6 @@
     </ion-row>
 
     <app-day-timeline
-      [intervals]="intervals"
       [appointments]="appointmentsService.appointments$"
       [startDate]="startDate"
       [endDate]="endDate"

--- a/src/app/agenda/agenda-details/agenda-details.page.html
+++ b/src/app/agenda/agenda-details/agenda-details.page.html
@@ -34,6 +34,7 @@
     </ion-row>
 
     <app-day-timeline
+      [intervals]="intervals"
       [appointments]="appointmentsService.appointments$"
       [startDate]="startDate"
       [endDate]="endDate"

--- a/src/app/agenda/agenda-details/agenda-details.page.html
+++ b/src/app/agenda/agenda-details/agenda-details.page.html
@@ -35,7 +35,7 @@
 
     <app-day-timeline
       [appointments]="appointmentsService.appointments$"
-      [intervals]="intervals"
+      [intervals]="intervals$"
       [startDate]="startDate"
       [endDate]="endDate"
       [intervalsLength]="interval"

--- a/src/app/agenda/agenda-details/agenda-details.page.ts
+++ b/src/app/agenda/agenda-details/agenda-details.page.ts
@@ -107,7 +107,7 @@ export class AgendaDetailsPage implements OnInit {
   ngOnInit() {
     setTimeout(() => {
       this.onDateChange(new Date());
-    }, 1000);
+    }, 1500);
   }
 
   ionViewDidEnter() {

--- a/src/app/components/agenda-intervals/agenda-intervals.component.html
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.html
@@ -1,5 +1,3 @@
 <div [style.height.px]="heightPx" [style.top.px]="topPx" class="interval-item">
-  <div *ngIf="interval" class="vertical-line">
-    HOlA
-  </div>
+  <div *ngIf="interval"></div>
 </div>

--- a/src/app/components/agenda-intervals/agenda-intervals.component.html
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.html
@@ -1,3 +1,3 @@
-<div [style.height.px]="heightPx" [style.top.px]="topPx" class="interval-item">
+<div [style.height.px]="200" [style.top.px]="100" class="interval-item">
   <div *ngIf="interval"></div>
 </div>

--- a/src/app/components/agenda-intervals/agenda-intervals.component.html
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.html
@@ -1,3 +1,3 @@
-<div [style.height.px]="200" [style.top.px]="100" class="interval-item">
+<div [style.height.px]="heightPx" [style.top.px]="topPx" class="interval-item">
   <div *ngIf="interval"></div>
 </div>

--- a/src/app/components/agenda-intervals/agenda-intervals.component.html
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.html
@@ -1,0 +1,5 @@
+<div [style.height.px]="heightPx" [style.top.px]="topPx" class="interval-item">
+  <div *ngIf="interval" class="vertical-line">
+    HOlA
+  </div>
+</div>

--- a/src/app/components/agenda-intervals/agenda-intervals.component.scss
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.scss
@@ -1,0 +1,9 @@
+.interval-item{
+  background-color: #f0f5ff;
+  position: absolute;
+  padding: 10px 16px 16px;
+  width: 80%;
+  left: 0;
+  margin-left: 18%;
+  z-index: 1;
+}

--- a/src/app/components/agenda-intervals/agenda-intervals.component.spec.ts
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+import { AgendaIntervalsComponent } from './agenda-intervals.component';
+
+describe('AgendaIntervalsComponent', () => {
+  let component: AgendaIntervalsComponent;
+  let fixture: ComponentFixture<AgendaIntervalsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AgendaIntervalsComponent],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AgendaIntervalsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/agenda-intervals/agenda-intervals.component.ts
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core';
 import * as moment from 'moment';
 import { Moment } from 'moment';
 import { Interval } from '../../interfaces/interval';
@@ -7,6 +12,7 @@ import { Interval } from '../../interfaces/interval';
   selector: 'app-agenda-intervals',
   templateUrl: './agenda-intervals.component.html',
   styleUrls: ['./agenda-intervals.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AgendaIntervalsComponent implements OnInit {
   @Input() startDate: Moment;
@@ -19,9 +25,8 @@ export class AgendaIntervalsComponent implements OnInit {
   topPx: number;
 
   ngOnInit() {
-    this.computeHeightAttribute();
-    this.computeTopProperty();
-    console.log(this.interval);
+    //this.computeHeightAttribute();
+    //this.computeTopProperty();
   }
 
   private computeHeightAttribute() {

--- a/src/app/components/agenda-intervals/agenda-intervals.component.ts
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.ts
@@ -30,10 +30,9 @@ export class AgendaIntervalsComponent implements OnInit {
   }
 
   private computeHeightAttribute() {
-    const minuteDiff = moment(this.interval.endHour, 'HH:mm').diff(
-      moment(this.interval.startHour, 'HH:mm'),
-      'minutes',
-    );
+    const minuteDiff = moment
+      .utc(this.interval.endHour, 'HH:mm')
+      .diff(moment.utc(this.interval.startHour, 'HH:mm'), 'minutes');
 
     const percentOfDayDuration = minuteDiff / this.dayLengthMinutes;
     this.heightPx = percentOfDayDuration * this.parentContainerLengthPx;
@@ -41,11 +40,12 @@ export class AgendaIntervalsComponent implements OnInit {
 
   private computeTopProperty() {
     const startDateString = this.startDate.toDate().toDateString();
-    const startHour = moment(startDateString + ' ' + this.interval.startHour);
-    const diffFromStartOfDay = moment(startHour).diff(
-      this.startDate,
-      'minutes',
+    const startHour = moment.utc(
+      startDateString + ' ' + this.interval.startHour,
     );
+    const diffFromStartOfDay = moment(startHour)
+      .local()
+      .diff(this.startDate, 'minutes');
     const percentOfTotalDayDuration =
       diffFromStartOfDay / this.dayLengthMinutes;
     this.topPx =

--- a/src/app/components/agenda-intervals/agenda-intervals.component.ts
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.ts
@@ -21,6 +21,7 @@ export class AgendaIntervalsComponent implements OnInit {
   ngOnInit() {
     this.computeHeightAttribute();
     this.computeTopProperty();
+    console.log(this.interval);
   }
 
   private computeHeightAttribute() {

--- a/src/app/components/agenda-intervals/agenda-intervals.component.ts
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.ts
@@ -25,8 +25,8 @@ export class AgendaIntervalsComponent implements OnInit {
   topPx: number;
 
   ngOnInit() {
-    //this.computeHeightAttribute();
-    //this.computeTopProperty();
+    this.computeHeightAttribute();
+    this.computeTopProperty();
   }
 
   private computeHeightAttribute() {
@@ -36,11 +36,13 @@ export class AgendaIntervalsComponent implements OnInit {
     );
 
     const percentOfDayDuration = minuteDiff / this.dayLengthMinutes;
-    this.heightPx = percentOfDayDuration * this.parentContainerLengthPx - 1; // -1 para separar visualmente citas adyacentes verticalemnte
+    this.heightPx = percentOfDayDuration * this.parentContainerLengthPx;
   }
 
   private computeTopProperty() {
-    const diffFromStartOfDay = moment(this.interval.startHour, 'HH:mm').diff(
+    const startDateString = this.startDate.toDate().toDateString();
+    const startHour = moment(startDateString + ' ' + this.interval.startHour);
+    const diffFromStartOfDay = moment(startHour).diff(
       this.startDate,
       'minutes',
     );

--- a/src/app/components/agenda-intervals/agenda-intervals.component.ts
+++ b/src/app/components/agenda-intervals/agenda-intervals.component.ts
@@ -1,0 +1,47 @@
+import { Component, Input, OnInit } from '@angular/core';
+import * as moment from 'moment';
+import { Moment } from 'moment';
+import { Interval } from '../../interfaces/interval';
+
+@Component({
+  selector: 'app-agenda-intervals',
+  templateUrl: './agenda-intervals.component.html',
+  styleUrls: ['./agenda-intervals.component.scss'],
+})
+export class AgendaIntervalsComponent implements OnInit {
+  @Input() startDate: Moment;
+  @Input() dayLengthMinutes: number;
+  @Input() parentContainerLengthPx: number;
+  @Input() parentPadding: number;
+  @Input() interval: Interval;
+
+  heightPx: number;
+  topPx: number;
+
+  ngOnInit() {
+    this.computeHeightAttribute();
+    this.computeTopProperty();
+  }
+
+  private computeHeightAttribute() {
+    const minuteDiff = moment(this.interval.endHour, 'HH:mm').diff(
+      moment(this.interval.startHour, 'HH:mm'),
+      'minutes',
+    );
+
+    const percentOfDayDuration = minuteDiff / this.dayLengthMinutes;
+    this.heightPx = percentOfDayDuration * this.parentContainerLengthPx - 1; // -1 para separar visualmente citas adyacentes verticalemnte
+  }
+
+  private computeTopProperty() {
+    const diffFromStartOfDay = moment(this.interval.startHour, 'HH:mm').diff(
+      this.startDate,
+      'minutes',
+    );
+    const percentOfTotalDayDuration =
+      diffFromStartOfDay / this.dayLengthMinutes;
+    this.topPx =
+      percentOfTotalDayDuration * this.parentContainerLengthPx +
+      this.parentPadding;
+  }
+}

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 import { TimelineAppointmentComponent } from './agenda-appointment/timeline-appointment.component';
+import { AgendaIntervalsComponent } from './agenda-intervals/agenda-intervals.component';
 import { AgendaNotificationsComponent } from './agenda-notifications/agenda-notifications.component';
 import { DatePickerComponent } from './date-picker/date-picker.component';
 import { DayTimelineComponent } from './day-timeline/day-timeline.component';
@@ -12,6 +13,7 @@ import { DayTimelineComponent } from './day-timeline/day-timeline.component';
     AgendaNotificationsComponent,
     TimelineAppointmentComponent,
     DayTimelineComponent,
+    AgendaIntervalsComponent,
   ],
   imports: [CommonModule, IonicModule],
   exports: [

--- a/src/app/components/day-timeline/day-timeline.component.html
+++ b/src/app/components/day-timeline/day-timeline.component.html
@@ -8,7 +8,7 @@
 
   <div class="intervals-wrapper">
     <app-agenda-intervals
-      *ngFor="let interval of this.intervals; index as i"
+      *ngFor="let interval of intervals | async; index as i"
       [startDate]="startDate"
       [dayLengthMinutes]="dayLengthMinutes"
       [parentContainerLengthPx]="componentHeight"

--- a/src/app/components/day-timeline/day-timeline.component.html
+++ b/src/app/components/day-timeline/day-timeline.component.html
@@ -6,6 +6,18 @@
     *ngFor="let block of this.timeBlocks; index as i"
   ></div>
 
+  <div class="intervals-wrapper">
+    <app-agenda-intervals
+      *ngFor="let interval of this.intervals; index as i"
+      [startDate]="startDate"
+      [dayLengthMinutes]="dayLengthMinutes"
+      [parentContainerLengthPx]="componentHeight"
+      [parentPadding]="padding"
+      [interval]="interval"
+    >
+    </app-agenda-intervals>
+  </div>
+
   <div class="appointments-wrapper">
     <app-agenda-appointment
       *ngFor="let appointment of appointments | async; index as i"

--- a/src/app/components/day-timeline/day-timeline.component.scss
+++ b/src/app/components/day-timeline/day-timeline.component.scss
@@ -23,8 +23,14 @@
   justify-content: flex-end;
 }
 
+.intervals-wrapper {
+  display: flex;
+  justify-content: flex-end;
+}
+
 
 .appointments-wrapper {
+  z-index: 0;
   display: flex;
   justify-content: flex-end;
 }

--- a/src/app/components/day-timeline/day-timeline.component.ts
+++ b/src/app/components/day-timeline/day-timeline.component.ts
@@ -1,4 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core';
 import { Duration, Moment } from 'moment';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Appointment } from '../../interfaces/appointment';
@@ -22,7 +27,7 @@ interface AppointmentBlock {
   selector: 'app-day-timeline',
   templateUrl: './day-timeline.component.html',
   styleUrls: ['./day-timeline.component.scss'],
-  //changeDetection: ChangeDetectionStrategy.OnPush,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DayTimelineComponent implements OnInit {
   @Input() appointments: Observable<Appointment[]>;

--- a/src/app/components/day-timeline/day-timeline.component.ts
+++ b/src/app/components/day-timeline/day-timeline.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Duration, Moment } from 'moment';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { Appointment } from '../../interfaces/appointment';
+import { Interval } from '../../interfaces/interval';
 import { AppointmentsService } from '../../services/appointments.service';
 
 interface TimeBlock {
@@ -25,6 +26,7 @@ interface AppointmentBlock {
 })
 export class DayTimelineComponent implements OnInit {
   @Input() appointments: Observable<Appointment[]>;
+  @Input() intervals: Interval[];
   @Input() startDate: Moment;
   @Input() endDate: Moment;
   @Input() intervalsLength: Duration;
@@ -41,6 +43,7 @@ export class DayTimelineComponent implements OnInit {
   constructor(private appointmentsService: AppointmentsService) {}
 
   ngOnInit() {
+    console.log(this.intervals);
     this.dayLengthMinutes = this.endDate.diff(this.startDate, 'minutes');
     const nBlocks = Math.floor(
       this.dayLengthMinutes / this.intervalsLength.asMinutes(),

--- a/src/app/components/day-timeline/day-timeline.component.ts
+++ b/src/app/components/day-timeline/day-timeline.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Duration, Moment } from 'moment';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { AgendaDetailsPage } from '../../agenda/agenda-details/agenda-details.page';
 import { Appointment } from '../../interfaces/appointment';
 import { Interval } from '../../interfaces/interval';
 import { AppointmentsService } from '../../services/appointments.service';
@@ -26,11 +27,12 @@ interface AppointmentBlock {
 })
 export class DayTimelineComponent implements OnInit {
   @Input() appointments: Observable<Appointment[]>;
-  @Input() intervals: Interval[];
   @Input() startDate: Moment;
   @Input() endDate: Moment;
   @Input() intervalsLength: Duration;
   @Input() padding = 16;
+
+  intervals: Observable<Interval[]>;
 
   timeBlocks: TimeBlock[] = [];
   dayLengthMinutes: number;
@@ -40,10 +42,16 @@ export class DayTimelineComponent implements OnInit {
     AppointmentBlock[]
   >([]);
 
-  constructor(private appointmentsService: AppointmentsService) {}
+  constructor(
+    private appointmentsService: AppointmentsService,
+    agenda: AgendaDetailsPage,
+  ) {
+    agenda.intervals.subscribe(data => {
+      this.intervals = of(data);
+    });
+  }
 
   ngOnInit() {
-    console.log(this.intervals);
     this.dayLengthMinutes = this.endDate.diff(this.startDate, 'minutes');
     const nBlocks = Math.floor(
       this.dayLengthMinutes / this.intervalsLength.asMinutes(),
@@ -53,21 +61,5 @@ export class DayTimelineComponent implements OnInit {
       .map(v => {
         return { start: v };
       });
-
-    /* this.appointments.subscribe(appointments => {
-      const appointmentBlockArray: AppointmentBlock[] = [];
-      appointments.map(appointment => {
-        // mirar si coinciden
-        appointmentBlockArray.push({
-          startDate: appointment.startDate,
-          endDate: appointment.endDate,
-          name: appointment.name,
-          customerName: appointment.customerName,
-          sharesStartTimeWithOtherAppointment: true,
-          positionSharing: 1,
-        });
-      });
-      this.appointmentBlocks.next(appointmentBlockArray);
-    }); */
   }
 }

--- a/src/app/components/day-timeline/day-timeline.component.ts
+++ b/src/app/components/day-timeline/day-timeline.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Duration, Moment } from 'moment';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { AgendaDetailsPage } from '../../agenda/agenda-details/agenda-details.page';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Appointment } from '../../interfaces/appointment';
 import { Interval } from '../../interfaces/interval';
 import { AppointmentsService } from '../../services/appointments.service';
@@ -27,12 +26,11 @@ interface AppointmentBlock {
 })
 export class DayTimelineComponent implements OnInit {
   @Input() appointments: Observable<Appointment[]>;
+  @Input() intervals: Observable<Interval[]>;
   @Input() startDate: Moment;
   @Input() endDate: Moment;
   @Input() intervalsLength: Duration;
   @Input() padding = 16;
-
-  intervals: Observable<Interval[]>;
 
   timeBlocks: TimeBlock[] = [];
   dayLengthMinutes: number;
@@ -42,14 +40,7 @@ export class DayTimelineComponent implements OnInit {
     AppointmentBlock[]
   >([]);
 
-  constructor(
-    private appointmentsService: AppointmentsService,
-    agenda: AgendaDetailsPage,
-  ) {
-    agenda.intervals.subscribe(data => {
-      this.intervals = of(data);
-    });
-  }
+  constructor(private appointmentsService: AppointmentsService) {}
 
   ngOnInit() {
     this.dayLengthMinutes = this.endDate.diff(this.startDate, 'minutes');

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -6,4 +6,5 @@ export abstract class FunctionNames {
     'getAvaliableTimeIntervals';
   public static readonly SET_AGENDA_SCHEDULE_SETTINGS =
     'setAgendaScheduleSettings';
+  public static readonly GET_AGENDA_CONFIG = 'getAgendaConfig';
 }

--- a/src/app/interfaces/agenda-config.ts
+++ b/src/app/interfaces/agenda-config.ts
@@ -1,0 +1,8 @@
+import { Interval } from './interval';
+
+export interface AgendaConfig {
+  expirationDate: string;
+  specificDate: string;
+  dayOfWeek: number;
+  intervals: Interval[];
+}

--- a/src/app/interfaces/interval.ts
+++ b/src/app/interfaces/interval.ts
@@ -1,0 +1,4 @@
+export interface Interval {
+  startHour: string;
+  endHour: string;
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -46,7 +46,6 @@ export class AuthService {
       switchMap(user => {
         // Logged in
         if (user) {
-          console.log(user.getIdToken());
           this.temporalUser = user;
           return this.firestore.doc<User>(`users/${user.uid}`).valueChanges();
         } else {
@@ -152,7 +151,6 @@ export class AuthService {
   }
 
   private async createUserInFirebaseIfNew(user: any): Promise<User> {
-    console.log(user);
     // Sets user data to firestore on login
     const userRef: AngularFirestoreDocument<User> = this.firestore.doc(
       `users/${user.uid}`,

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -46,6 +46,7 @@ export class AuthService {
       switchMap(user => {
         // Logged in
         if (user) {
+          console.log(user.getIdToken());
           this.temporalUser = user;
           return this.firestore.doc<User>(`users/${user.uid}`).valueChanges();
         } else {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -46,6 +46,7 @@ export class AuthService {
       switchMap(user => {
         // Logged in
         if (user) {
+          // console.log(user.getIdToken());
           this.temporalUser = user;
           return this.firestore.doc<User>(`users/${user.uid}`).valueChanges();
         } else {

--- a/src/app/services/get-agenda-config.service.spec.ts
+++ b/src/app/services/get-agenda-config.service.spec.ts
@@ -1,0 +1,11 @@
+import { TestBed } from '@angular/core/testing';
+import { GetAgendaConfigService } from './get-agenda-config.service';
+
+describe('GetAgendaConfigService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: GetAgendaConfigService = TestBed.get(GetAgendaConfigService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/get-agenda-config.service.ts
+++ b/src/app/services/get-agenda-config.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { AngularFireFunctions } from '@angular/fire/functions';
+import { Observable } from 'rxjs';
+import { FunctionNames } from '../constants';
+import { Interval } from '../interfaces/interval';
+
+export interface GetAgendaConfigDTO {
+  agendaId: string;
+  businessId: string;
+  showOnlyValidConfig: boolean;
+}
+
+export interface GetAgendaConfigResponse {
+  result: {
+    expirationDate: string;
+    specificDate: string;
+    dayOfWeek: number;
+    intervals: Interval[];
+  }[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GetAgendaConfigService {
+  private readonly _endpoint: (
+    data: GetAgendaConfigDTO,
+  ) => Observable<GetAgendaConfigResponse>;
+
+  constructor(private functions: AngularFireFunctions) {
+    this._endpoint = this.functions.httpsCallable<
+      GetAgendaConfigDTO,
+      GetAgendaConfigResponse
+    >(FunctionNames.GET_AGENDA_CONFIG);
+  }
+
+  get endpoint() {
+    return this._endpoint;
+  }
+}


### PR DESCRIPTION
## JIRA ISSUE - Mostrar las horas internas a las que esta abierta la agenda

## Objetivo de la PR

Se requiere que el usuario de la app entienda visualmente a que horas su agenda está abierta. La agenda de “abre” según su configuración. Por ejmplo, un negocio puede decidir abrir agenda lunes y martes de 10 a 14.

## Como probar

Crear una agenda y añadir varias configuraciones (de momento desde firebase) con diferentes intervalos. Se puede usar una agenda ya creada pero hay que añadir las configuraciones.

Probar a cambiar de días y comprobar que todo funciona como debería.

## Comentarios adicionales y requerimientos para el revisor.

Prueba funcional
